### PR TITLE
feat: support video files as pause icon

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "Auf Standardwerte zurücksetzen",
     "RESET_DEFAULTS_DONE": "Pause Customizer Einstellungen auf Standardwerte zurückgesetzt.",
     "SELECT_IMAGE": "Pause-Icon",
-    "SELECT_IMAGE_HINT": "Bild für das Pause-Icon. Über den Ordner-Button einen Ordner für zufällige Bilder auswählen."
+    "SELECT_IMAGE_HINT": "Bild oder Video für das Pause-Icon. Über den Ordner-Button einen Ordner für zufällige Bilder auswählen. Videos benötigen WebM-Format in der Foundry Desktop-App."
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "Reset to Defaults",
     "RESET_DEFAULTS_DONE": "Pause Customizer settings reset to defaults.",
     "SELECT_IMAGE": "Pause icon",
-    "SELECT_IMAGE_HINT": "Image used as the pause icon. Use the folder button to select a folder for random images."
+    "SELECT_IMAGE_HINT": "Image or video used as the pause icon. Use the folder button to select a folder for random images. Videos require WebM format in the Foundry desktop app."
   }
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "Restablecer valores predeterminados",
     "RESET_DEFAULTS_DONE": "Configuración de Pause Customizer restablecida a los valores predeterminados.",
     "SELECT_IMAGE": "Icono de pausa",
-    "SELECT_IMAGE_HINT": "Imagen utilizada como icono de pausa. Use el botón de carpeta para seleccionar una carpeta de imágenes aleatorias."
+    "SELECT_IMAGE_HINT": "Imagen o video utilizado como icono de pausa. Use el botón de carpeta para seleccionar una carpeta de imágenes aleatorias. Los videos requieren formato WebM en la aplicación de escritorio de Foundry."
   }
 }

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "Réinitialiser les valeurs par défaut",
     "RESET_DEFAULTS_DONE": "Paramètres de Pause Customizer réinitialisés aux valeurs par défaut.",
     "SELECT_IMAGE": "Icône de pause",
-    "SELECT_IMAGE_HINT": "Image utilisée comme icône de pause. Utilisez le bouton dossier pour sélectionner un dossier d'images aléatoires."
+    "SELECT_IMAGE_HINT": "Image ou vidéo utilisée comme icône de pause. Utilisez le bouton dossier pour sélectionner un dossier d'images aléatoires. Les vidéos nécessitent le format WebM dans l'application de bureau Foundry."
   }
 }

--- a/languages/ja.json
+++ b/languages/ja.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "デフォルトに戻す",
     "RESET_DEFAULTS_DONE": "Pause Customizerの設定がデフォルトにリセットされました。",
     "SELECT_IMAGE": "一時停止アイコン",
-    "SELECT_IMAGE_HINT": "一時停止アイコンとして使用する画像。フォルダボタンでランダム画像用のフォルダを選択できます。"
+    "SELECT_IMAGE_HINT": "一時停止アイコンとして使用する画像または動画。フォルダボタンでランダム画像用のフォルダを選択できます。Foundryデスクトップアプリでは動画にWebM形式が必要です。"
   }
 }

--- a/languages/pt-br.json
+++ b/languages/pt-br.json
@@ -47,6 +47,6 @@
     "RESET_DEFAULTS": "Restaurar padrões",
     "RESET_DEFAULTS_DONE": "Configurações do Pause Customizer restauradas para os valores padrão.",
     "SELECT_IMAGE": "Ícone de pausa",
-    "SELECT_IMAGE_HINT": "Imagem utilizada como ícone de pausa. Use o botão de pasta para selecionar uma pasta de imagens aleatórias."
+    "SELECT_IMAGE_HINT": "Imagem ou vídeo utilizado como ícone de pausa. Use o botão de pasta para selecionar uma pasta de imagens aleatórias. Vídeos requerem formato WebM no aplicativo desktop do Foundry."
   }
 }

--- a/src/pause-customizer.ts
+++ b/src/pause-customizer.ts
@@ -34,12 +34,13 @@ let directoryImages: string[] = [];
  */
 async function loadDirectoryImages(path: string): Promise<void> {
   directoryImages = [];
-  if (!path || /\.(jpg|jpeg|png|gif|svg|webp|avif|bmp|tiff?)$/i.test(path)) return;
+  if (!path || /\.(jpg|jpeg|png|gif|svg|webp|avif|bmp|tiff?|mp4|webm|ogg)$/i.test(path)) return;
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = await (FilePicker as any).browse('data', path);
+    const FP = (foundry as any).applications.apps.FilePicker.implementation;
+    const result = await FP.browse('data', path);
     directoryImages = (result.files as string[]).filter((f: string) =>
-      /\.(jpg|jpeg|png|gif|svg|webp|avif|bmp|tiff?)$/i.test(f)
+      /\.(jpg|jpeg|png|gif|svg|webp|avif|bmp|tiff?|mp4|webm|ogg)$/i.test(f)
     );
   } catch {
     directoryImages = [];
@@ -61,7 +62,7 @@ Hooks.once('init', () => {
     config: true,
     type: String,
     default: '',
-    filePicker: 'image',
+    filePicker: 'imagevideo',
     requiresReload: false,
   });
 
@@ -316,13 +317,13 @@ Hooks.once('setup', () => {
 });
 
 // Re-render the pause overlay whenever our settings change
-Hooks.on('updateSetting', (setting: { key?: string }) => {
+Hooks.on('updateSetting', async (setting: { key?: string }) => {
   if (setting.key?.startsWith(`${MODULE_ID}.`)) {
     // Refresh directory image cache when the icon path changes
     if (setting.key === `${MODULE_ID}.${SETTINGS.CHOOSE_FILE}`) {
       const settings = game.settings as unknown as FoundrySettings;
       const pauseImage = settings.get(MODULE_ID, SETTINGS.CHOOSE_FILE) as string;
-      loadDirectoryImages(pauseImage);
+      await loadDirectoryImages(pauseImage);
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pause = (ui as any).pause as { render?: (opts?: object) => void } | undefined;
@@ -535,7 +536,8 @@ Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement) => {
           'input[type="text"]'
         ) as HTMLInputElement | null;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        new (FilePicker as any)({
+        const FP = (foundry as any).applications.apps.FilePicker.implementation;
+        new FP({
           type: 'folder',
           callback: (path: string) => {
             if (innerInput) {
@@ -667,7 +669,7 @@ Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement) => {
     if (!context.cssClass?.includes('paused')) return;
 
     const settings = game.settings as unknown as FoundrySettings;
-    const img = element.querySelector('img') as HTMLElement | null;
+    let img = element.querySelector('img') as HTMLElement | null;
     const caption = element.querySelector('figcaption') as HTMLElement | null;
     if (!img || !caption) return;
 
@@ -739,13 +741,39 @@ Hooks.on('renderSettingsConfig', (_app: unknown, html: HTMLElement) => {
     const pauseBackground = settings.get(MODULE_ID, SETTINGS.PAUSE_BACKGROUND) as string;
     const pauseBackgroundImage = settings.get(MODULE_ID, SETTINGS.PAUSE_BACKGROUND_IMAGE) as string;
 
-    // --- Image ---
+    // --- Image / Video ---
 
+    let resolvedSrc = '';
     if (directoryImages.length > 0) {
-      const randomImage = directoryImages[Math.floor(Math.random() * directoryImages.length)]!;
-      img.setAttribute('src', randomImage);
+      resolvedSrc = directoryImages[Math.floor(Math.random() * directoryImages.length)]!;
     } else if (pauseImage) {
-      img.setAttribute('src', pauseImage);
+      resolvedSrc = pauseImage;
+    }
+
+    if (resolvedSrc && /\.(mp4|webm|ogg)$/i.test(resolvedSrc)) {
+      const video = document.createElement('video');
+      // Set muted before src — required for autoplay policy
+      video.setAttribute('muted', '');
+      video.muted = true;
+      video.autoplay = true;
+      video.loop = true;
+      video.playsInline = true;
+      video.className = img.className;
+      video.style.objectFit = 'contain';
+      // Copy computed styles from img since CSS rules target img, not video
+      const cs = getComputedStyle(img);
+      video.style.position = cs.position;
+      video.style.top = cs.top;
+      video.style.left = cs.left;
+      video.style.width = cs.width;
+      video.style.height = cs.height;
+      video.style.opacity = cs.opacity;
+      img.replaceWith(video);
+      video.src = resolvedSrc;
+      video.play().catch(() => {});
+      img = video;
+    } else if (resolvedSrc) {
+      img.setAttribute('src', resolvedSrc);
     }
 
     if (imageWidth) {


### PR DESCRIPTION
## Summary
- Allow image and video files (mp4, webm, ogg) as pause icon via `filePicker: 'imagevideo'`
- When a video is selected, `<img>` is replaced with `<video autoplay loop muted playsinline>`
- Computed styles are copied from the original `<img>` to preserve system-specific positioning
- Updates `FilePicker` to use v14 namespaced API (`foundry.applications.apps.FilePicker.implementation`)
- Hint text updated in all 6 languages with WebM recommendation for Foundry desktop app

Closes #13

## Test plan
- [x] Select a video file (webm) via the file picker — verify it plays in the pause overlay
- [x] Select an image file — verify it still works as before
- [x] Verify video has autoplay, loop, muted, and correct positioning
- [x] Verify no deprecation warnings in console for FilePicker
- [x] Test with DnD5e system and vanilla Foundry

🤖 Generated with [Claude Code](https://claude.com/claude-code)