### PR TITLE
docs: update README for v2, fix funding URLs

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 github: marcstraube
 ko_fi: marcstraube
-patreon: NerdyByNature
+patreon: marcstraube
 custom: "https://paypal.me/marcstraube"

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # Pause Customizer
 
-![All Releases Download Count](https://img.shields.io/github/downloads/marcstraube/foundryvtt-pause-customizer/module.zip?color=2b82fc&label=%20Downloads%20%28all%29&style=for-the-badge)
-![Latest Release Download Count](https://img.shields.io/github/downloads/marcstraube/foundryvtt-pause-customizer/latest/module.zip?label=Downloads%20%28latest%20release%29&style=for-the-badge)
-![GitHub release (latest by date)](https://img.shields.io/github/v/release/marcstraube/foundryvtt-pause-customizer?label=Latest%20Release&prefix=v&query=$.version&colorB=red&style=for-the-badge)
-![Foundry Core Minimal Compatible Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmarcstraube%2Ffoundryvtt-pause-customizer%2Fmaster%2Fmodule.json&label=Foundry%20Version&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
-[![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fpause-customizer&colorB=006400&style=for-the-badge)](https://forge-vtt.com/bazaar#package=pause-customizer)
-[![ko-fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/J3J1FVK91)
-[![Patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/NerdyByNatureDev)
+[![CI](https://img.shields.io/github/actions/workflow/status/marcstraube/foundryvtt-pause-customizer/ci.yml?label=CI&style=for-the-badge)](https://github.com/marcstraube/foundryvtt-pause-customizer/actions/workflows/ci.yml)
+![Downloads](https://img.shields.io/github/downloads/marcstraube/foundryvtt-pause-customizer/module.zip?color=2b82fc&label=Downloads&style=for-the-badge)
+![Latest Release](https://img.shields.io/github/v/release/marcstraube/foundryvtt-pause-customizer?label=Release&prefix=v&query=$.version&colorB=red&style=for-the-badge)
+![Foundry Version](https://img.shields.io/badge/dynamic/json.svg?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmarcstraube%2Ffoundryvtt-pause-customizer%2Fmaster%2Fmodule.json&label=Foundry&query=$.compatibility.minimum&colorB=orange&style=for-the-badge)
+[![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fpause-customizer&colorB=006400&style=for-the-badge)](https://forge-vtt.com/bazaar#package=pause-customizer)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/marcstraube)
+[![Patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)](https://patreon.com/marcstraube)
 
-[![Weblate Translation Status](https://weblate.foundryvtt-hub.com/widgets/pause-customizer/-/287x66-black.png)](https://weblate.foundryvtt-hub.com/engage/pause-customizer/)
-
-A small module to customize the pause image, animation style and pause text.
+A module to fully customize the FoundryVTT pause overlay — icon, text,
+animation, positioning and background.
 
 This module is based on the
 [Custom Pause](https://gitlab.com/jestevens210/custom-pause/) module by John
@@ -18,14 +17,68 @@ Stevens.
 
 ![FVTT Icon](images/custom-pause.gif)
 
-## How to Use This Module
+## Features
 
-- Open Module Settings: Select the path to the desired image, the animation
-  settings and/or the pause text, then "Save Changes" and reload FoundryVtt.
-- Pause/Unpause: Use space bar to Pause/Unpause and see the new pause animation.
+### Icon
 
-For possible settings values and more information about them, see the follwing
-links:
+- Custom pause icon (image or video)
+- Image width and height
+- Opacity
+- Vertical offset
+- Video support (mp4, webm, ogg) with autoplay and loop
+
+### Text
+
+- Custom pause text
+- Font family, size, weight
+- Text color
+- Text transform (uppercase, lowercase, capitalize)
+- Letter spacing
+- Text shadow
+- Vertical offset
+
+### Animation
+
+- Animation direction (rotate, reverse, alternate, none)
+- Animation duration
+- Animation timing function
+
+### Background
+
+- Custom CSS background (color, gradient, etc.)
+- Background image
+
+### Random Pause Image
+
+Select a folder instead of a single file to randomly pick an image each time the
+game is paused. Use the folder button next to the file picker.
+
+### Additional Features
+
+- Dynamic system defaults — automatically detects and displays default values
+  from the active game system (e.g. DnD5e)
+- Reset to defaults button
+- No reload required — changes apply on save without reloading Foundry
+- Supports 6 languages: English, German, Spanish, French, Japanese, Portuguese
+  (Brazil)
+
+## Video Support
+
+Videos can be used as the pause icon instead of a static image. Supported
+formats: mp4, webm, ogg.
+
+> **Note:** The Foundry desktop app (Electron) requires **WebM format** for
+> video playback due to codec limitations. MP4 works when accessing Foundry via
+> a web browser.
+
+## How to Use
+
+1. Open **Module Settings** for Pause Customizer.
+2. Configure the desired settings — changes apply immediately.
+3. Use the file picker button to select an image/video, or the folder button to
+   select a folder for random images.
+
+For possible CSS values and more information, see:
 
 - [Animation Direction](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-direction)
 - [Animation Duration](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-duration)
@@ -48,3 +101,15 @@ links:
 - Paste the following link into the "Manifest URL" field at the bottom:
   <https://github.com/marcstraube/foundryvtt-pause-customizer/releases/latest/download/module.json>
 - Click **Install**.
+
+## Contributing
+
+Translations are managed via
+[Weblate](https://weblate.foundryvtt-hub.com/engage/pause-customizer/). Feel
+free to contribute translations for your language.
+
+## Support
+
+If you enjoy this module, consider supporting its development on
+[Ko-fi](https://ko-fi.com/marcstraube) or
+[Patreon](https://patreon.com/marcstraube).


### PR DESCRIPTION
## Summary
- Rewrite README to document all v2 features (video support, random images, vertical offsets, dynamic system defaults)
- Fix Ko-fi and Patreon URLs to point to marcstraube (were still pointing to original module creator)
- Add CI badge, compact badge labels
- Add contributing section with Weblate link
- Add support section with funding links

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Verify all links work (Ko-fi, Patreon, Weblate, Forge, CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)