### PR TITLE
ci: exclude internal changes from release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,12 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'chore'
+  - 'ci'
+  - 'build'
+  - 'test'
+  - 'style'
+  - 'dependencies'
 categories:
   - title: 'Features'
     labels:
@@ -32,25 +39,6 @@ categories:
     labels:
       - 'security'
     collapse-after: 5
-  - title: 'Build & CI'
-    labels:
-      - 'build'
-      - 'ci'
-      - 'chore'
-    collapse-after: 5
-  - title: 'Tests'
-    labels:
-      - 'test'
-      - 'tests'
-    collapse-after: 5
-  - title: 'Code Style'
-    labels:
-      - 'style'
-    collapse-after: 5
-category-template: |
-  ### $TITLE
-
-  $CHANGES
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 version-resolver:


### PR DESCRIPTION
## Summary

- Excludes `chore`, `ci`, `build`, `test`, `style` and the dependabot-default `dependencies` label from release-drafter output — these are internal-only changes that never affect end users of the Foundry module.
- Drops the now-unused **Build & CI**, **Tests** and **Code Style** categories.
- Removes the custom `category-template`. The default template (`## \$TITLE\n\n\$CHANGES`) avoids a v6 quirk where `\$CHANGES` is left literal in incrementally updated drafts (visible in the current v2.0.1 draft).

After this lands we'll delete the current `v2.0.1` draft so release-drafter regenerates it cleanly with the new config — it should then contain only `feat`/`fix`/`docs`/`refactor`/`perf`/`security` changes.

## Test plan

- [ ] After merge, check that the regenerated draft shows only #30 under \"Bug Fixes\" (the i18n fix) and no longer contains the dependabot dev-deps bump or the literal `\$CHANGES` artifact
- [ ] Verify contributor list shows only @marcstraube