### PR TITLE
ci: exclude dependabot[bot] from release contributors

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,8 @@ exclude-labels:
   - 'test'
   - 'style'
   - 'dependencies'
+exclude-contributors:
+  - 'dependabot[bot]'
 categories:
   - title: 'Features'
     labels:


### PR DESCRIPTION
## Summary

Dependabot's PRs are already filtered out of the release notes by the `dependencies`/`chore` label exclusions (added in #31), but release-drafter still lists `dependabot[bot]` under **Contributors** because it walks every PR author since the previous release — regardless of whether their PRs ended up in the changelog.

This adds `exclude-contributors: [dependabot[bot]]` so the bot is dropped from the contributor line entirely.

## Test plan

- [ ] After merge, regenerate the v2.0.1 draft and verify the contributor line shows only `@marcstraube` (no dependabot)