### PR TITLE
ci: also exclude app/dependabot login from contributors

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -9,6 +9,7 @@ exclude-labels:
   - 'dependencies'
 exclude-contributors:
   - 'dependabot[bot]'
+  - 'app/dependabot'
 categories:
   - title: 'Features'
     labels:


### PR DESCRIPTION
## Summary

Follow-up to #32. GitHub returns two different logins for the Dependabot bot:

- `dependabot[bot]` for **commit authors**
- `app/dependabot` for **PR authors**

Excluding only the commit-author form still left the App-form showing up under "Contributors" with its markdown link form. This adds the second form too.

## Test plan

- [ ] After merge, delete and regenerate the v2.0.1 draft and verify the contributor line shows only `@marcstraube`