### PR TITLE
ci: bump Node.js to 22 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/format-weblate.yml
+++ b/.github/workflows/format-weblate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
Bumps the Node.js version from 20 to 22 in all GitHub Actions workflows.

The recent Dependabot major updates require Node.js >= 22:
- `@commitlint/cli` 21.2.0 (#48)
- `@commitlint/config-conventional` 21.2.0 (#49)
- `lint-staged` 17.0.8 (#50)

All three drop Node 18/20 support. These tools only run as local Husky
hooks (not in CI), so CI was not failing — but aligning the workflow
runtime with the new engine requirement keeps things consistent.

## Affected workflows
- `.github/workflows/ci.yml`
- `.github/workflows/main.yml`
- `.github/workflows/format-weblate.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)