### PR TITLE
ci: fix Auto-format git-over-HTTPS and set verified compatibility 14.360

### DIFF
--- a/.github/workflows/format-weblate.yml
+++ b/.github/workflows/format-weblate.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure git to use HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
   "version": "This is auto replaced",
   "compatibility": {
     "minimum": "14",
-    "verified": "14",
+    "verified": "14.360",
     "maximum": "14"
   },
   "esmodules": ["./dist/pause-customizer.js"],


### PR DESCRIPTION
## Summary

Release prep for v2.0.2.

## Changes
- **CI fix:** The Auto-format (Weblate) workflow was missing the git-over-HTTPS rewrite that `ci.yml` and `main.yml` already have, so `pnpm install --frozen-lockfile` failed cloning a git dependency over SSH on the runner ([run 29010919031](https://github.com/marcstraube/foundryvtt-pause-customizer/actions/runs/29010919031)). Added the same `Configure git to use HTTPS` step.
- **Release metadata:** Set `compatibility.verified` to `14.360` (the tested Foundry build) for the 2.0.2 release.

The Auto-format workflow only triggers on `languages/**` changes, so this PR does not re-run it; the fix applies to the next translation-file push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
